### PR TITLE
Fix plugin when using TT-RSS in a subdirectory.

### DIFF
--- a/init.js
+++ b/init.js
@@ -1,4 +1,4 @@
-require(['dojo/_base/kernel', 'dojo/ready', '/plugins.local/favicon_badge/favico.min.js'], function (dojo,  ready, Favico) {
+require(['dojo/_base/kernel', 'dojo/ready', 'plugins.local/favicon_badge/favico.min.js'], function (dojo,  ready, Favico) {
   let favicon = new Favico({
     animation : 'none'
   });


### PR DESCRIPTION
It no longer checks for favico.min.js in the root directory of the website.